### PR TITLE
restore sending of payment emails to tournament payment notifiable contacts

### DIFF
--- a/app/jobs/stripe/checkout_session_completed.rb
+++ b/app/jobs/stripe/checkout_session_completed.rb
@@ -96,6 +96,14 @@ module Stripe
         identifier: cs[:payment_intent]
       )
       TournamentRegistration.send_receipt_email(bowler, external_payment.id) unless bowler.tournament.config[:stripe_receipts]
+
+      TournamentRegistration.notify_payment_contacts(
+        bowler,
+        external_payment.id,
+        cs[:amount_total] / 100,
+        event[:created]
+      )
+
       scp.completed!
     end
 

--- a/spec/support/shared_examples/stripe_event_handlers.rb
+++ b/spec/support/shared_examples/stripe_event_handlers.rb
@@ -12,4 +12,9 @@ RSpec.shared_examples 'a completed checkout session' do
   it 'creates a Stripe LedgerEntry for the bowler' do
     expect { subject }.to change { bowler.ledger_entries.stripe.count }.by(1)
   end
+
+  it 'notifies tournament contacts who want to be notified individually' do
+    expect(TournamentRegistration).to receive(:notify_payment_contacts).once
+    subject
+  end
 end


### PR DESCRIPTION
For some reason, it stopped getting called somewhere along the way. (Probably as part of the transition from PayPal to Stripe.)