### PR TITLE
December code release

### DIFF
--- a/app/blueprints/config_item_blueprint.rb
+++ b/app/blueprints/config_item_blueprint.rb
@@ -4,6 +4,8 @@ class ConfigItemBlueprint < Blueprinter::Base
   field :value do |c, _|
     if %w(email_in_dev display_capacity skip_stripe publicly_listed accept_payments automatic_discount_voids automatic_late_fees stripe_receipts).include?(c.key)
       self.boolean_value(c.value)
+    elsif c.key == 'bowler_form_fields'
+      c.value.split(' ')
     else
       c.value
     end

--- a/app/blueprints/shift_blueprint.rb
+++ b/app/blueprints/shift_blueprint.rb
@@ -2,7 +2,7 @@
 
 class ShiftBlueprint < Blueprinter::Base
   identifier :identifier
-  fields :name, :description, :capacity, :display_order, :is_full
+  fields :name, :description, :capacity, :display_order, :is_full, :group_title, :event_string
 
   field :team_count do |shift, _|
     shift.teams.count

--- a/app/blueprints/team_blueprint.rb
+++ b/app/blueprints/team_blueprint.rb
@@ -6,7 +6,7 @@ class TeamBlueprint < Blueprinter::Base
   field :initial_size
 
   association :tournament, blueprint: TournamentBlueprint
-  association :shift, blueprint: ShiftBlueprint
+  association :shifts, blueprint: ShiftBlueprint
 
   view :list do
     field :name do |t, _|
@@ -34,12 +34,6 @@ class TeamBlueprint < Blueprinter::Base
     end
     field :place_with_others do |t, _|
       t.options['place_with_others'].nil? ? 'n/a' : t.options['place_with_others']
-    end
-
-    field :shift do |t, _|
-      if t.shift.present?
-        ShiftBlueprint.render_as_hash(t.shift)
-      end
     end
 
     field :who_has_paid do |t, _|

--- a/app/blueprints/tournament_blueprint.rb
+++ b/app/blueprints/tournament_blueprint.rb
@@ -92,6 +92,10 @@ class TournamentBlueprint < Blueprinter::Base
     field :event_items do |t, _|
       organized_event_items(tournament: t)
     end
+
+    field :shifts_by_event do |t, _|
+      shifts_by_events(tournament: t)
+    end
   end
 
   view :director_detail do
@@ -240,5 +244,15 @@ class TournamentBlueprint < Blueprinter::Base
       ledger: PurchasableItemBlueprint.render_as_hash(ledger_items.sort_by { |li| determination_order[li.determination.to_sym] }),
       event: PurchasableItemBlueprint.render_as_hash(event_items.sort_by { |ei| event_refinement_order[ei.refinement.to_sym] }),
     }
+  end
+
+  def self.shifts_by_events(tournament:)
+    tournament.shifts.each_with_object({}) do |shift, collector|
+      event_string = shift.event_string
+      if collector[event_string].blank?
+        collector[event_string] = []
+      end
+      collector[event_string] << ShiftBlueprint.render_as_hash(shift)
+    end
   end
 end

--- a/app/blueprints/tournament_blueprint.rb
+++ b/app/blueprints/tournament_blueprint.rb
@@ -124,10 +124,6 @@ class TournamentBlueprint < Blueprinter::Base
       output
     end
 
-    field :additional_questions do |t, _|
-      t.additional_questions.order(:order).each_with_object([]) { |aq, obj| obj << AdditionalQuestionBlueprint.render_as_hash(aq) }
-    end
-
     field :available_questions do |t, _|
       if t.setup? || t.testing? || t.demo?
         ExtendedFormField.where.not(id: t.additional_questions.select(:extended_form_field_id)).collect do |eff|

--- a/app/controllers/director/teams_controller.rb
+++ b/app/controllers/director/teams_controller.rb
@@ -135,6 +135,7 @@ module Director
     def edit_team_params
       parameters = params.require(:team).permit(
         :name,
+        :initial_size,
         shift_identifiers: [],
         bowlers_attributes: %i[id position doubles_partner_id],
       ).to_h.with_indifferent_access

--- a/app/controllers/director/teams_controller.rb
+++ b/app/controllers/director/teams_controller.rb
@@ -45,12 +45,7 @@ module Director
 
       authorize tournament, :update?
 
-      # new_team_params = { tournament: tournament }.merge(team_params)
-      new_team_params = team_params
-      shift = Shift.find_by_identifier(new_team_params[:shift_identifier])
-      new_team_params.delete :shift_identifier
-
-      team = Team.new({ tournament: tournament }.merge(new_team_params.merge(shift_id: shift.id)))
+      team = Team.new({ tournament: tournament }.merge(new_team_params))
       unless team.valid?
         render json: nil, status: :bad_request
         return
@@ -73,16 +68,9 @@ module Director
 
       authorize tournament
       new_values = edit_team_params
-
-      if new_values['shift_identifier'].present?
-        # This isn't a normal RESTful request.
-        new_values['shift_id'] = new_shift_id new_values['shift_identifier']
-        new_values.delete 'shift_identifier'
-      else
-        unless positions_valid?(new_values)
-          render json: { errors: ['Positions must be unique across the team'] }, status: :bad_request
-          return
-        end
+      unless positions_valid?(new_values)
+        render json: { errors: ['Positions must be unique across the team'] }, status: :bad_request
+        return
       end
 
       unless team.update(new_values)
@@ -130,32 +118,37 @@ module Director
       @tournament = team.tournament if team.present?
     end
 
-    def team_params
-      params.require(:team).permit(
+    def new_team_params
+      parameters = params.require(:team).permit(
         :name,
         :initial_size,
-        :shift_identifier,
+        shift_identifiers: [],
         options: {},
       ).to_h.symbolize_keys
+
+      parameters[:shifts] = Shift.where(identifier: parameters[:shift_identifiers])
+      parameters.delete(:shift_identifiers)
+
+      parameters
     end
 
     def edit_team_params
-      params.require(:team).permit(
+      parameters = params.require(:team).permit(
         :name,
-        :initial_size,
-        :shift_identifier,
+        shift_identifiers: [],
         bowlers_attributes: %i[id position doubles_partner_id],
       ).to_h.with_indifferent_access
+
+      parameters[:shifts] = Shift.where(identifier: parameters[:shift_identifiers])
+      raise ActiveRecord::RecordNotFound unless parameters[:shift_identifiers].blank? || parameters[:shifts].count == parameters[:shift_identifiers].count
+      parameters.delete(:shift_identifiers)
+
+      parameters
     end
 
     def positions_valid?(proposed_values)
-      positions = proposed_values[:bowlers_attributes].collect { |attrs| attrs[:position] }
-      positions.count == positions.uniq.count
-    end
-
-    def new_shift_id(new_shift_identifier)
-      new_shift = Shift.find_by!(identifier: new_shift_identifier)
-      new_shift.id
+      positions = proposed_values[:bowlers_attributes]&.collect { |attrs| attrs[:position] }
+      positions.nil? || positions.count == positions.uniq.count
     end
   end
 end

--- a/app/controllers/director/tournaments_controller.rb
+++ b/app/controllers/director/tournaments_controller.rb
@@ -47,6 +47,7 @@ module Director
         :id,
         :roster_type,
         :name,
+        :game_count,
         :required,
         :scratch,
         :entry_fee, # not a model attribute
@@ -151,6 +152,7 @@ module Director
       authorize Tournament
 
       tournament = Tournament.new(create_params)
+
       if tournament.valid?
         tournament.save
       else
@@ -395,6 +397,24 @@ module Director
     end
 
     def create_params
+      # Add standard events to each new tournament
+      params[:tournament][:events_attributes] = [
+        {
+          name: 'Singles',
+          roster_type: :single,
+          game_count: 3,
+        },
+        {
+          name: 'Doubles',
+          roster_type: :double,
+          game_count: 3,
+        },
+        {
+          name: 'Team',
+          roster_type: :team,
+          game_count: 3,
+        },
+      ]
       params.require(:tournament).permit(TOURNAMENT_PARAMS << :identifier)
     end
   end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -134,8 +134,11 @@ class TeamsController < ApplicationController
     cleaned_up = permitted_params.dup
     cleaned_up['bowlers_attributes'].map! { |bowler_attrs| clean_up_bowler_data(bowler_attrs) }
 
-    if tournament.shifts.count > 1
-      raise MissingShiftIdentifiers.new('Missing preferred shift identifiers') unless permitted_params['shift_identifiers'].present?
+    if tournament.shifts.count > 0
+      # We need to specify shift_identifiers if there are more than one to choose from
+      if tournament.shifts.count > 1 && permitted_params['shift_identifiers'].blank?
+        raise MissingShiftIdentifiers.new('Missing preferred shift identifiers')
+      end
 
       cleaned_up['shifts'] = Shift.where(identifier: permitted_params['shift_identifiers'])
       cleaned_up.delete('shift_identifiers')

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -54,11 +54,13 @@ class TeamsController < ApplicationController
       return
     end
 
-    # if team.shift.is_full?
-    #   Rails.logger.warn "======== Requested shift is full. Errors: #{team.errors.full_messages}"
-    #   render json: { team: 'Requested shift is full' }, status: :unprocessable_entity
-    #   return
-    # end
+    # Prevent joining a shift that is already marked as full
+    full_shifts = team.shifts.filter { |s| s.is_full? }
+    if full_shifts.any?
+      shift_names = full_shifts.collect(&:name).join(', ')
+      render json: { team: "Cannot join a full shift: #{shift_names}" }, status: :unprocessable_entity
+      return
+    end
 
     TournamentRegistration.register_team(team)
 

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -30,7 +30,7 @@ class TeamsController < ApplicationController
   TEAM_ATTRS = [
     :name,
     :initial_size,
-    :shift_identifier,
+    shift_identifiers: [],
     bowlers_attributes: BOWLER_ATTRS,
     options: {},
   ].freeze
@@ -54,11 +54,11 @@ class TeamsController < ApplicationController
       return
     end
 
-    if team.shift.is_full?
-      Rails.logger.warn "======== Requested shift is full. Errors: #{team.errors.full_messages}"
-      render json: { team: 'Requested shift is full' }, status: :unprocessable_entity
-      return
-    end
+    # if team.shift.is_full?
+    #   Rails.logger.warn "======== Requested shift is full. Errors: #{team.errors.full_messages}"
+    #   render json: { team: 'Requested shift is full' }, status: :unprocessable_entity
+    #   return
+    # end
 
     TournamentRegistration.register_team(team)
 
@@ -119,11 +119,6 @@ class TeamsController < ApplicationController
       b.tournament = tournament
     end
 
-    # When there's only one shift, ignore the provided shift_identifier parameter.
-    if tournament.shifts.count == 1
-      team.shift_id = tournament.shifts.first.id
-    end
-
     team
   end
 
@@ -131,9 +126,8 @@ class TeamsController < ApplicationController
     cleaned_up = permitted_params.dup
     cleaned_up['bowlers_attributes'].map! { |bowler_attrs| clean_up_bowler_data(bowler_attrs) }
 
-    shift = Shift.find_by(identifier: permitted_params['shift_identifier'])
-    cleaned_up['shift_id'] = shift.id unless shift.nil?
-    cleaned_up.delete('shift_identifier')
+    cleaned_up['shifts'] = Shift.where(identifier: permitted_params['shift_identifiers'])
+    cleaned_up.delete('shift_identifiers')
 
     cleaned_up
   end

--- a/app/lib/director_utilities.rb
+++ b/app/lib/director_utilities.rb
@@ -176,7 +176,7 @@ module DirectorUtilities
         team_id: team.id, # team.identifier,
         team_name: team.name,
         team_order: bowler.position,
-        preferred_shift: team.shift&.name,
+        preferred_shift: team.shifts.collect(&:name).join(', '),
       }
     else
       {

--- a/app/lib/tournament_business.rb
+++ b/app/lib/tournament_business.rb
@@ -46,7 +46,9 @@ module TournamentBusiness
       ConfigItem.new(key: 'automatic_late_fees', value: 'false', label: 'Automatically Charge Unpaid Bowlers the Late Fee'),
       ConfigItem.new(key: 'website', value: '', label: 'Website'),
       ConfigItem.new(key: 'stripe_receipts', value: 'true', label: 'Send Receipt Emails'),
+      ConfigItem.new(key: 'team_size', value: 4, label: 'Team Size'),
       ConfigItem.new(key: 'tournament_type', value: IGBO_STANDARD, label: 'Tournament Type'),
+      ConfigItem.new(key: 'bowler_form_fields', value: '', label: 'Bowler Form Fields')
     ]
 
     if Rails.env.development?

--- a/app/lib/tournament_business.rb
+++ b/app/lib/tournament_business.rb
@@ -3,6 +3,12 @@
 module TournamentBusiness
   DEFAULT_TEAM_SIZE = 4
 
+  # Tournament types
+  IGBO_STANDARD = 'igbo_standard'
+  IGBO_MULTI_SHIFT = 'igbo_multi_shift'
+  IGBO_MIX_AND_MATCH = 'igbo_mix_and_match'
+  # IGBO_NON_STANDARD = 'igbo_non_standard'
+
   def entry_fee
     purchasable_items.entry_fee.first.value
   end
@@ -29,6 +35,26 @@ module TournamentBusiness
 
   def config
     @config ||= TournamentConfig.new(config_items)
+  end
+
+  def create_default_config
+    self.config_items += [
+      ConfigItem.new(key: 'display_capacity', value: 'false', label: 'Display Capacity'),
+      ConfigItem.new(key: 'publicly_listed', value: 'true', label: 'Publicly Listed'), # applies to tournaments in the "active" state
+      ConfigItem.new(key: 'accept_payments', value: 'true', label: 'Accept Payments'),
+      ConfigItem.new(key: 'automatic_discount_voids', value: 'false', label: 'Automatically Void Early Discounts'),
+      ConfigItem.new(key: 'automatic_late_fees', value: 'false', label: 'Automatically Charge Unpaid Bowlers the Late Fee'),
+      ConfigItem.new(key: 'website', value: '', label: 'Website'),
+      ConfigItem.new(key: 'stripe_receipts', value: 'true', label: 'Send Receipt Emails'),
+      ConfigItem.new(key:'tournament_type', value: IGBO_STANDARD)
+    ]
+
+    if Rails.env.development?
+      self.config_items += [
+        ConfigItem.new(key: 'email_in_dev', value: 'false', label: '[dev] Send Emails'),
+        ConfigItem.new(key: 'skip_stripe', value: 'true', label: 'Skip Stripe'),
+      ]
+    end
   end
 
   def late_fee_applies_at

--- a/app/lib/tournament_business.rb
+++ b/app/lib/tournament_business.rb
@@ -46,7 +46,7 @@ module TournamentBusiness
       ConfigItem.new(key: 'automatic_late_fees', value: 'false', label: 'Automatically Charge Unpaid Bowlers the Late Fee'),
       ConfigItem.new(key: 'website', value: '', label: 'Website'),
       ConfigItem.new(key: 'stripe_receipts', value: 'true', label: 'Send Receipt Emails'),
-      ConfigItem.new(key:'tournament_type', value: IGBO_STANDARD, label: 'Tournament Type'),
+      ConfigItem.new(key: 'tournament_type', value: IGBO_STANDARD, label: 'Tournament Type'),
     ]
 
     if Rails.env.development?

--- a/app/lib/tournament_business.rb
+++ b/app/lib/tournament_business.rb
@@ -46,7 +46,7 @@ module TournamentBusiness
       ConfigItem.new(key: 'automatic_late_fees', value: 'false', label: 'Automatically Charge Unpaid Bowlers the Late Fee'),
       ConfigItem.new(key: 'website', value: '', label: 'Website'),
       ConfigItem.new(key: 'stripe_receipts', value: 'true', label: 'Send Receipt Emails'),
-      ConfigItem.new(key:'tournament_type', value: IGBO_STANDARD)
+      ConfigItem.new(key:'tournament_type', value: IGBO_STANDARD, label: 'Tournament Type'),
     ]
 
     if Rails.env.development?

--- a/app/models/config_item.rb
+++ b/app/models/config_item.rb
@@ -20,10 +20,4 @@
 class ConfigItem < ApplicationRecord
   belongs_to :tournament
   default_scope { order(key: :asc) }
-
-  before_create do |ci|
-    if ci.key == 'website'
-      ci.label = 'Website'
-    end
-  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -19,6 +19,7 @@
 #
 class Event < ApplicationRecord
   belongs_to :tournament
+  has_and_belongs_to_many :shifts
   has_and_belongs_to_many :scratch_divisions
 
   accepts_nested_attributes_for :scratch_divisions

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -5,22 +5,22 @@
 # Table name: people
 #
 #  id          :bigint           not null, primary key
-#  address1    :string           not null
+#  address1    :string
 #  address2    :string
-#  birth_day   :integer          not null
-#  birth_month :integer          not null
-#  city        :string           not null
-#  country     :string           not null
+#  birth_day   :integer
+#  birth_month :integer
+#  birth_year  :integer
+#  city        :string
+#  country     :string
 #  email       :string           not null
 #  first_name  :string           not null
 #  last_name   :string           not null
 #  nickname    :string
 #  phone       :string           not null
-#  postal_code :string           not null
-#  state       :string           not null
+#  postal_code :string
+#  state       :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  igbo_id     :string
 #  usbc_id     :string
 #
 # Indexes
@@ -36,13 +36,6 @@ class Person < ApplicationRecord
 
   validates :first_name,
             :last_name,
-            :address1,
-            :city,
-            :state,
-            :country,
-            :postal_code,
-            :birth_month,
-            :birth_day,
             :email,
             :phone,
             presence: { message: 'is required' }

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -35,6 +35,8 @@ class Shift < ApplicationRecord
   private
 
   def generate_identifier
-    self.identifier = SecureRandom.uuid
+    begin
+      self.identifier = SecureRandom.alphanumeric(6)
+    end while Shift.exists?(identifier: self.identifier)
   end
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -6,6 +6,8 @@
 #  capacity      :integer          default(128), not null
 #  description   :string
 #  display_order :integer          default(1), not null
+#  event_string  :string
+#  group_title   :string
 #  identifier    :string           not null
 #  is_full       :boolean          default(FALSE)
 #  name          :string
@@ -28,6 +30,8 @@ class Shift < ApplicationRecord
   scope :available, -> { where(is_full: false) }
 
   before_create :generate_identifier, if: -> { identifier.blank? }
+  before_save :generate_event_string, if: -> { events.any? }
+  before_save :generate_group_title, if: -> { events.any? }
 
   def to_param
     identifier
@@ -39,5 +43,13 @@ class Shift < ApplicationRecord
     begin
       self.identifier = SecureRandom.alphanumeric(6)
     end while Shift.exists?(identifier: self.identifier)
+  end
+
+  def generate_event_string
+    self.event_string = events.collect(&:roster_type).sort.join('_')
+  end
+
+  def generate_group_title
+    self.group_title = events.collect(&:name).sort.join(' & ')
   end
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -20,7 +20,7 @@
 #
 class Shift < ApplicationRecord
   belongs_to :tournament
-  has_many :teams
+  has_and_belongs_to_many :teams
 
   validates :capacity, numericality: { greater_than: 0 }
 

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -21,6 +21,7 @@
 class Shift < ApplicationRecord
   belongs_to :tournament
   has_and_belongs_to_many :teams
+  has_and_belongs_to_many :events
 
   validates :capacity, numericality: { greater_than: 0 }
 

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -50,6 +50,6 @@ class Shift < ApplicationRecord
   end
 
   def generate_group_title
-    self.group_title = events.collect(&:name).sort.join(' & ')
+    self.group_title = events.collect(&:name).join(' / ')
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -25,7 +25,11 @@ class Team < ApplicationRecord
   include TeamBusiness
 
   belongs_to :tournament
-  belongs_to :shift
+
+  # @mix-and-match Create a migration to drop shift_id from this table
+
+  has_and_belongs_to_many :shifts
+
   has_many :bowlers, -> { order(position: :asc) }, dependent: :destroy
   accepts_nested_attributes_for :bowlers
 

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -126,23 +126,6 @@ class Tournament < ApplicationRecord
     self.testing_environment = TestingEnvironment.new(conditions: TestingEnvironment.defaultConditions)
   end
 
-  def create_default_config
-    self.config_items << ConfigItem.new(key: 'display_capacity', value: 'false', label: 'Display Capacity')
-    self.config_items << ConfigItem.new(key: 'publicly_listed', value: 'true', label: 'Publicly Listed') # applies to tournaments in the "active" state
-    self.config_items << ConfigItem.new(key: 'accept_payments', value: 'true', label: 'Accept Payments')
-    self.config_items << ConfigItem.new(key: 'automatic_discount_voids', value: 'false', label: 'Automatically Void Early Discounts')
-    self.config_items << ConfigItem.new(key: 'automatic_late_fees', value: 'false', label: 'Automatically Charge Unpaid Bowlers the Late Fee')
-
-    self.config_items << ConfigItem.new(key: 'stripe_receipts', value: 'true', label: 'Send Receipt Emails')
-
-    if Rails.env.development?
-      self.config_items += [
-        ConfigItem.new(key: 'email_in_dev', value: 'false', label: '[dev] Send Emails'),
-        ConfigItem.new(key: 'skip_stripe', value: 'true', label: 'Skip Stripe'),
-      ]
-    end
-  end
-
   def clear_data
     return unless demo?
     teams.destroy_all

--- a/app/serializers/shift_serializer.rb
+++ b/app/serializers/shift_serializer.rb
@@ -8,6 +8,8 @@
 #  capacity      :integer          default(128), not null
 #  description   :string
 #  display_order :integer          default(1), not null
+#  event_string  :string
+#  group_title   :string
 #  identifier    :string           not null
 #  is_full       :boolean          default(FALSE)
 #  name          :string

--- a/app/serializers/team_serializer.rb
+++ b/app/serializers/team_serializer.rb
@@ -31,5 +31,5 @@ class TeamSerializer
   attributes :identifier, :name, :initial_size, :created_at
 
   # one :tournament, resource: TournamentSerializer
-  one :shift, resource: ShiftSerializer
+  many :shifts, resource: ShiftSerializer
 end

--- a/db/data/20230817161103_create_automatic_discount_voids_config_items.rb
+++ b/db/data/20230817161103_create_automatic_discount_voids_config_items.rb
@@ -3,7 +3,7 @@
 class CreateAutomaticDiscountVoidsConfigItems < ActiveRecord::Migration[7.0]
   def up
     Tournament.all.each do |t|
-      t.config_items << ConfigItem.new(key: 'automatic_discount_voids', label: 'Automatically Void Early Discounts', value: false)
+      t.config_items << ConfigItem.new(key: 'automatic_discount_voids', label: 'Automatically Void Early Discounts', value: false) unless t.config_items.exists?(key: 'automatic_discount_voids')
     end
   end
 

--- a/db/data/20230817224154_create_automatic_late_fee_config_items.rb
+++ b/db/data/20230817224154_create_automatic_late_fee_config_items.rb
@@ -3,7 +3,7 @@
 class CreateAutomaticLateFeeConfigItems < ActiveRecord::Migration[7.0]
   def up
     Tournament.all.each do |t|
-      t.config_items << ConfigItem.new(key: 'automatic_late_fees', label: 'Automatically Charge Unpaid Bowlers the Late Fee', value: false)
+      t.config_items << ConfigItem.new(key: 'automatic_late_fees', label: 'Automatically Charge Unpaid Bowlers the Late Fee', value: false) unless t.config_items.exists?(key: 'automatic_late_fees')
     end
   end
 

--- a/db/data/20230919200152_create_stripe_receipts_config_items.rb
+++ b/db/data/20230919200152_create_stripe_receipts_config_items.rb
@@ -3,7 +3,7 @@
 class CreateStripeReceiptsConfigItems < ActiveRecord::Migration[7.0]
   def up
     Tournament.upcoming.each do |t|
-      t.config_items << ConfigItem.new(key: 'stripe_receipts', value: false, label: 'Send receipts via Stripe') unless ConfigItem.exists?(key: 'stripe_receipts', tournament: t)
+      t.config_items << ConfigItem.new(key: 'stripe_receipts', value: false, label: 'Send receipts via Stripe') unless t.config_items.exists?(key: 'stripe_receipts')
     end
   end
 

--- a/db/data/20231102204456_move_team_shift_to_shift_team.rb
+++ b/db/data/20231102204456_move_team_shift_to_shift_team.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class MoveTeamShiftToShiftTeam < ActiveRecord::Migration[7.0]
+  def up
+    Tournament.all.each do |tournament|
+      tournament.teams.where.not(shift_id: nil).each do |team|
+        shift = Shift.find(team.shift_id)
+        team.shifts << shift
+      end
+    end
+  end
+
+  def down
+    Tournament.all.each do |tournament|
+      tournament.teams.includes(:shifts).each do |team|
+        shift = team.shifts.first
+        next unless shift.present?
+        team.update(shift_id: shift.id)
+      end
+    end
+  end
+end

--- a/db/data/20231117202500_create_bowler_form_field_rows.rb
+++ b/db/data/20231117202500_create_bowler_form_field_rows.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateBowlerFormFieldRows < ActiveRecord::Migration[7.0]
+  def up
+    Tournament.upcoming.each do |t|
+      t.config_items << ConfigItem.new(key: 'bowler_form_fields', label: 'Bowler Form Fields', value: 'address1 city state country postal_code usbc_id date_of_birth') unless t.config_items.exists?(key: 'bowler_form_fields')
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20230923220535)
+DataMigrate::Data.define(version: 20231117202500)

--- a/db/migrate/20231102155728_create_events_shifts.rb
+++ b/db/migrate/20231102155728_create_events_shifts.rb
@@ -1,0 +1,8 @@
+class CreateEventsShifts < ActiveRecord::Migration[7.0]
+  def change
+    create_join_table :events, :shifts do |t|
+      t.index :event_id
+      t.index :shift_id
+    end
+  end
+end

--- a/db/migrate/20231102160543_create_shifts_teams.rb
+++ b/db/migrate/20231102160543_create_shifts_teams.rb
@@ -1,0 +1,8 @@
+class CreateShiftsTeams < ActiveRecord::Migration[7.0]
+  def change
+    create_join_table :shifts, :teams do |t|
+      t.index :team_id
+      t.index :shift_id
+    end
+  end
+end

--- a/db/migrate/20231113193935_add_event_string_to_shifts.rb
+++ b/db/migrate/20231113193935_add_event_string_to_shifts.rb
@@ -1,0 +1,6 @@
+class AddEventStringToShifts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :shifts, :event_string, :string
+    add_column :shifts, :group_title, :string
+  end
+end

--- a/db/migrate/20231116164853_change_person_fields_to_nullable.rb
+++ b/db/migrate/20231116164853_change_person_fields_to_nullable.rb
@@ -1,0 +1,15 @@
+class ChangePersonFieldsToNullable < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :people, :address1, true
+    change_column_null :people, :birth_day, true
+    change_column_null :people, :birth_month, true
+    change_column_null :people, :city, true
+    change_column_null :people, :country, true
+    change_column_null :people, :postal_code, true
+    change_column_null :people, :state, true
+
+    remove_column :people, :igbo_id, :string
+
+    add_column :people, :birth_year, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_20_155523) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_02_155728) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -149,6 +149,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_20_155523) do
     t.bigint "event_id", null: false
     t.bigint "scratch_division_id", null: false
     t.index ["event_id", "scratch_division_id"], name: "event_division_idx", unique: true
+  end
+
+  create_table "events_shifts", id: false, force: :cascade do |t|
+    t.bigint "event_id", null: false
+    t.bigint "shift_id", null: false
+    t.index ["event_id"], name: "index_events_shifts_on_event_id"
+    t.index ["shift_id"], name: "index_events_shifts_on_shift_id"
   end
 
   create_table "extended_form_fields", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_02_160543) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_13_193935) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -312,6 +312,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_02_160543) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "is_full", default: false
+    t.string "event_string"
+    t.string "group_title"
     t.index ["identifier"], name: "index_shifts_on_identifier", unique: true
     t.index ["tournament_id"], name: "index_shifts_on_tournament_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_02_155728) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_02_160543) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -314,6 +314,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_02_155728) do
     t.boolean "is_full", default: false
     t.index ["identifier"], name: "index_shifts_on_identifier", unique: true
     t.index ["tournament_id"], name: "index_shifts_on_tournament_id"
+  end
+
+  create_table "shifts_teams", id: false, force: :cascade do |t|
+    t.bigint "shift_id", null: false
+    t.bigint "team_id", null: false
+    t.index ["shift_id"], name: "index_shifts_teams_on_shift_id"
+    t.index ["team_id"], name: "index_shifts_teams_on_team_id"
   end
 
   create_table "stripe_accounts", primary_key: "identifier", id: :string, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_13_193935) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_16_164853) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -225,20 +225,20 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_13_193935) do
     t.string "first_name", null: false
     t.string "last_name", null: false
     t.string "email", null: false
-    t.integer "birth_month", null: false
-    t.integer "birth_day", null: false
+    t.integer "birth_month"
+    t.integer "birth_day"
     t.string "nickname"
-    t.string "address1", null: false
+    t.string "address1"
     t.string "address2"
-    t.string "city", null: false
-    t.string "state", null: false
-    t.string "postal_code", null: false
-    t.string "country", null: false
+    t.string "city"
+    t.string "state"
+    t.string "postal_code"
+    t.string "country"
     t.string "phone", null: false
-    t.string "igbo_id"
     t.string "usbc_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "birth_year"
     t.index ["last_name"], name: "index_people_on_last_name"
     t.index ["usbc_id"], name: "index_people_on_usbc_id"
   end

--- a/db/seeds/extended_form_fields.seeds.rb
+++ b/db/seeds/extended_form_fields.seeds.rb
@@ -22,7 +22,7 @@ ExtendedFormField.create(
 
 ExtendedFormField.create(
   name: 'pronouns',
-  label: 'Preferred pronouns',
+  label: 'Personal pronouns',
   html_element_type: 'select',
   html_element_config: {
     options: [
@@ -258,26 +258,6 @@ ExtendedFormField.create(
   helper_text: '',
   helper_url: '',
 ) unless ExtendedFormField.find_by(name: 'igbo_rep').present?
-
-ExtendedFormField.create(
-  name: 'friday_team_event',
-  label: "Would you be able to bowl the Team Event on Friday at 8pm?",
-  html_element_type: 'checkbox',
-  html_element_config: { label: 'Yes', value: 'no' },
-  validation_rules: { required: false },
-  helper_text: '',
-  helper_url: '',
-) unless ExtendedFormField.find_by(name: 'friday_team_event').present?
-
-ExtendedFormField.create(
-  name: 'has_free_entry',
-  label: "I have a free entry",
-  html_element_type: 'checkbox',
-  html_element_config: { label: '', value: 'no' },
-  validation_rules: { required: false },
-  helper_text: '',
-  helper_url: '',
-) unless ExtendedFormField.find_by(name: 'has_free_entry').present?
 
 ExtendedFormField.create(
   name: 'igbo_tad_average',

--- a/db/seeds/mix_and_match_shifts.rb
+++ b/db/seeds/mix_and_match_shifts.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+tournament = Tournament.find_by_identifier('')
+
+singles = Event.create(name: 'Singles', game_count: 3, roster_type: :single, tournament: tournament)
+doubles = Event.create(name: 'Doubles', game_count: 3, roster_type: :double, tournament: tournament)
+team = Event.create(name: 'Team', game_count: 3, roster_type: :team, tournament: tournament)
+
+tournament.shifts = [
+  Shift.new(display_order: 1, name: 'SD1', description: 'Saturday 9am-3pm', events: [singles, doubles]),
+  Shift.new(display_order: 2, name: 'SD2', description: 'Friday 5-11pm', events: [singles, doubles]),
+  Shift.new(display_order: 3, name: 'T1', description: 'Thursday 7-10pm', events: [team]),
+  Shift.new(display_order: 4, name: 'T2', description: 'Saturday 4:30-8pm', events: [team]),
+]

--- a/spec/blueprints/shift_blueprint_spec.rb
+++ b/spec/blueprints/shift_blueprint_spec.rb
@@ -9,7 +9,7 @@ describe ShiftBlueprint do
 
     before do
       team_count.times do
-        create :team, tournament: tournament, shift: shift
+        create :team, tournament: tournament, shifts: [shift]
       end
     end
 

--- a/spec/blueprints/tournament_blueprint_spec.rb
+++ b/spec/blueprints/tournament_blueprint_spec.rb
@@ -10,18 +10,16 @@ describe TournamentBlueprint do
     let(:entry_deadline) { (Time.zone.today + 20.days).iso8601 }
     let(:location) { 'San Diego, CA' }
     let(:timezone) { 'America/Los_Angeles' }
-    let(:website) { 'https://tourn.io' }
     let(:abbreviation) { 'QUART' }
 
     before do
       tournament.config_items += [
-        ConfigItem.new(key: 'abbreviation', value: abbreviation),
-        ConfigItem.new(key: 'start_date', value: start_date),
-        ConfigItem.new(key: 'end_date', value: end_date),
-        ConfigItem.new(key: 'entry_deadline', value: entry_deadline),
-        ConfigItem.new(key: 'location', value: location),
-        ConfigItem.new(key: 'timezone', value: timezone),
-        ConfigItem.new(key: 'website', value: website),
+        ConfigItem.new(key: :abbreviation, value: abbreviation),
+        ConfigItem.new(key: :start_date, value: start_date),
+        ConfigItem.new(key: :end_date, value: end_date),
+        ConfigItem.new(key: :entry_deadline, value: entry_deadline),
+        ConfigItem.new(key: :location, value: location),
+        ConfigItem.new(key: :timezone, value: timezone),
       ]
     end
 

--- a/spec/factories/bowlers.rb
+++ b/spec/factories/bowlers.rb
@@ -33,7 +33,7 @@ FactoryBot.define do
     trait :with_team do
       position { 1 }
 
-      team { build :team, tournament: tournament, shift: tournament.shifts.first }
+      team { build :team, tournament: tournament }
     end
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -19,6 +19,19 @@
 #
 FactoryBot.define do
   factory :event do
-    ScratchDivision { "MyString" }
+    trait :singles do
+      roster_type { :single }
+      name { 'Singles Event' }
+    end
+
+    trait :doubles do
+      roster_type { :double }
+      name { 'Doubles Event' }
+    end
+
+    trait :team do
+      roster_type { :team }
+      name { 'Team Event' }
+    end
   end
 end

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -5,22 +5,22 @@
 # Table name: people
 #
 #  id          :bigint           not null, primary key
-#  address1    :string           not null
+#  address1    :string
 #  address2    :string
-#  birth_day   :integer          not null
-#  birth_month :integer          not null
-#  city        :string           not null
-#  country     :string           not null
+#  birth_day   :integer
+#  birth_month :integer
+#  birth_year  :integer
+#  city        :string
+#  country     :string
 #  email       :string           not null
 #  first_name  :string           not null
 #  last_name   :string           not null
 #  nickname    :string
 #  phone       :string           not null
-#  postal_code :string           not null
-#  state       :string           not null
+#  postal_code :string
+#  state       :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  igbo_id     :string
 #  usbc_id     :string
 #
 # Indexes

--- a/spec/factories/shifts.rb
+++ b/spec/factories/shifts.rb
@@ -6,6 +6,8 @@
 #  capacity      :integer          default(128), not null
 #  description   :string
 #  display_order :integer          default(1), not null
+#  event_string  :string
+#  group_title   :string
 #  identifier    :string           not null
 #  is_full       :boolean          default(FALSE)
 #  name          :string

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -25,7 +25,6 @@ FactoryBot.define do
   factory :team do
     name { 'Strike Force' }
     tournament
-    shift { tournament.shifts.first }
 
     trait :standard_one_bowler do
       after(:create) do |team, _|

--- a/spec/factories/tournaments.rb
+++ b/spec/factories/tournaments.rb
@@ -86,6 +86,21 @@ FactoryBot.define do
       end
     end
 
+    trait :mix_and_match_shifts do
+      after(:create) do |t, _|
+        singles = create :event, :singles, tournament: t
+        doubles = create :event, :doubles, tournament: t
+        team = create :event, :team, tournament: t
+
+        t.shifts = [
+          build(:shift, name: 'SD1', description: 'S&D early', events: [singles, doubles]),
+          build(:shift, name: 'SD2', description: 'S&D late', events: [singles, doubles]),
+          build(:shift, name: 'T1', description: 'T early', events: [team]),
+          build(:shift, name: 'T2', description: 'T late', events: [team]),
+        ]
+      end
+    end
+
     trait :with_entry_fee do
       after(:create) do |t, _|
         create(:purchasable_item,

--- a/spec/lib/director_utilities_spec.rb
+++ b/spec/lib/director_utilities_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe DirectorUtilities do
     subject { described_class.igbots_hash(tournament: tournament) }
 
     let(:tournament) { create :tournament, :one_shift }
-    let(:team) { create :team, tournament: tournament }
+    let(:team) { create :team, tournament: tournament, shifts: tournament.shifts }
     let!(:b1) { create(:bowler, tournament: tournament, position: 1, person: create(:person), team: team) }
     let!(:b2) { create(:bowler, tournament: tournament, position: 2, person: create(:person), team: team) }
     let!(:b3) { create(:bowler, tournament: tournament, position: 3, person: create(:person), team: team) }

--- a/spec/lib/tournament_business_spec.rb
+++ b/spec/lib/tournament_business_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe TournamentBusiness do
 
     context 'with a config item for team size' do
       before do
-        tournament.config_items << ConfigItem.new(key: 'team_size', value: 6)
+        tournament.config_items.find_by(key: 'team_size').update(value: 6)
       end
 
       it { is_expected.to eq(6) }

--- a/spec/lib/tournament_config_spec.rb
+++ b/spec/lib/tournament_config_spec.rb
@@ -8,14 +8,16 @@ RSpec.describe TournamentConfig do
 
   describe '#[]' do
     let!(:c1) { create :config_item, :email_in_dev, tournament: tournament, value: 'true' }
-    let!(:c2) { create :config_item, :website, tournament: tournament }
+    let(:url) { 'www.igbo.org' }
+
+    before { tournament.config_items.find_by_key('website').update(value: url) }
 
     it 'accepts a string argument' do
-      expect(tournament_config['website']).to eq(c2.value)
+      expect(tournament_config['website']).to eq(url)
     end
 
     it 'accepts a symbol argument' do
-      expect(tournament_config[:website]).to eq(c2.value)
+      expect(tournament_config[:website]).to eq(url)
     end
 
     it 'returns null when the key is not present' do
@@ -43,7 +45,6 @@ RSpec.describe TournamentConfig do
 
   describe '#[]=' do
     let!(:c1) { create :config_item, :email_in_dev, tournament: tournament, value: 'true' }
-    let!(:c2) { create :config_item, :website, tournament: tournament }
 
     subject { tournament_config[key] = new_value }
 
@@ -53,7 +54,8 @@ RSpec.describe TournamentConfig do
 
       it 'updates the config item value' do
         subject
-        expect(c2.reload.value).to eq(new_value)
+        config_item = tournament.config_items.find_by_key(key)
+        expect(config_item.value).to eq(new_value)
       end
     end
 
@@ -63,7 +65,8 @@ RSpec.describe TournamentConfig do
 
       it 'updates the config item value' do
         subject
-        expect(c2.reload.value).to eq(new_value)
+        config_item = tournament.config_items.find_by_key(key)
+        expect(config_item.value).to eq(new_value)
       end
     end
 
@@ -73,7 +76,8 @@ RSpec.describe TournamentConfig do
 
       it 'updates the config item value' do
         subject
-        expect(c2.reload.value).to eq(new_value.to_s)
+        config_item = tournament.config_items.find_by_key(key)
+        expect(config_item.value.to_i).to eq(new_value)
       end
     end
 

--- a/spec/lib/tournament_config_spec.rb
+++ b/spec/lib/tournament_config_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe TournamentConfig do
     end
 
     context 'an integer value' do
-      let!(:c3) { create :config_item, key: 'team_size', value: 42, tournament: tournament }
+      before { tournament.config_items.find_by(key: 'team_size').update(value: 42) }
 
       it 'returns the value as an integer' do
         expect(tournament_config['team_size']).to be_instance_of Integer

--- a/spec/lib/tournament_registration_spec.rb
+++ b/spec/lib/tournament_registration_spec.rb
@@ -499,7 +499,7 @@ RSpec.describe TournamentRegistration do
     subject { subject_class.complete_doubles_link(new_bowler) }
 
     let(:tournament) { create :tournament, :active }
-    let(:team) { create :team, tournament: tournament, shift: tournament.shifts.first }
+    let(:team) { create :team, tournament: tournament, shifts: [tournament.shifts.first] }
 
     context 'when no partner is available' do
       let(:new_bowler) { create(:bowler, person: create(:person), tournament: tournament, position: 3) }
@@ -816,7 +816,7 @@ RSpec.describe TournamentRegistration do
     subject { subject_class.try_assigning_automatic_partners(team) }
 
     let(:tournament) { create :tournament, :active }
-    let(:team) { create :team, tournament: tournament, shift: tournament.shifts.first }
+    let(:team) { create :team, tournament: tournament, shifts: [tournament.shifts.first] }
 
     context 'when the team is not yet full' do
       let(:new_bowler) { bowlers.last }

--- a/spec/migrate/data/move_team_shift_to_shift_team_spec.rb
+++ b/spec/migrate/data/move_team_shift_to_shift_team_spec.rb
@@ -87,6 +87,68 @@ RSpec.describe MoveTeamShiftToShiftTeam do
   end
 
   describe 'down' do
+    subject { described_class.new.down }
 
+    context 'a tournament with just one shift' do
+      let(:tournament) { create :tournament }
+      let(:shift) { tournament.shifts.first }
+
+      context 'a team with no bowlers' do
+        let!(:team) do
+          create :team,
+            tournament: tournament,
+            shifts: [shift]
+        end
+
+        it 'adds the shift to the belongs-to relationship' do
+          subject
+          expect(team.reload.shift_id).to eq(shift.id)
+        end
+      end
+
+      context 'a team with bowlers' do
+        let!(:team) do
+          create :team, :standard_full_team,
+            tournament: tournament,
+            shifts: [tournament.shifts.last]
+        end
+
+        it 'adds the shift to the belongs-to relationship' do
+          subject
+          expect(team.reload.shift_id).to eq(shift.id)
+        end
+      end
+    end
+
+    context 'a tournament with two shifts' do
+      let(:tournament) { create :tournament, :two_shifts }
+      let(:shift) { tournament.shifts.last }
+
+      context 'a team with no bowlers' do
+        let!(:team) do
+          create :team,
+            tournament: tournament,
+            shifts: [shift]
+        end
+
+        it 'adds the shift to the belongs-to relationship' do
+          subject
+          expect(team.reload.shift_id).to eq(shift.id)
+        end
+      end
+
+      context 'a team with bowlers' do
+        let!(:team) do
+          create :team, :standard_full_team,
+            tournament: tournament,
+            shifts: [tournament.shifts.last]
+        end
+
+        it 'adds the shift to the belongs-to relationship' do
+          subject
+          expect(team.reload.shift_id).to eq(shift.id)
+        end
+      end
+    end
   end
 end

--- a/spec/migrate/data/move_team_shift_to_shift_team_spec.rb
+++ b/spec/migrate/data/move_team_shift_to_shift_team_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+Dir[Rails.root.join('db', 'data', '**', '*.rb')].sort.each { |f| require f }
+
+RSpec.describe MoveTeamShiftToShiftTeam do
+  describe 'up' do
+    subject { described_class.new.up }
+
+    context 'a tournament with just one shift' do
+      let(:tournament) { create :tournament }
+      let(:shift) { tournament.shifts.first }
+
+      context 'a team with no bowlers' do
+        let!(:team) do
+          create :team,
+            tournament: tournament,
+            shift_id: shift.id
+        end
+
+        it 'adds the shift to the HABTM relationship' do
+          subject
+          expect(team.shifts).to match_array([shift])
+        end
+
+        it 'leaves the original shift_id intact' do
+          expect { subject }.not_to change(team, :shift_id)
+        end
+      end
+
+      context 'a team with bowlers' do
+        let!(:team) do
+          create :team, :standard_full_team,
+            tournament: tournament,
+            shift_id: tournament.shifts.last.id
+        end
+
+        it 'adds the shift to the HABTM relationship' do
+          subject
+          expect(team.shifts).to match_array([shift])
+        end
+
+        it 'leaves the original shift_id intact' do
+          expect { subject }.not_to change(team, :shift_id)
+        end
+      end
+    end
+
+    context 'a tournament with two shifts' do
+      let(:tournament) { create :tournament, :two_shifts }
+      let(:shift) { tournament.shifts.last }
+
+      context 'a team with no bowlers' do
+        let!(:team) do
+          create :team,
+            tournament: tournament,
+            shift_id: shift.id
+        end
+
+        it 'adds the shift to the HABTM relationship' do
+          subject
+          expect(team.shifts).to match_array([shift])
+        end
+
+        it 'leaves the original shift_id intact' do
+          expect { subject }.not_to change(team, :shift_id)
+        end
+      end
+
+      context 'a team with bowlers' do
+        let!(:team) do
+          create :team, :standard_full_team,
+            tournament: tournament,
+            shift_id: tournament.shifts.last.id
+        end
+
+        it 'adds the shift to the HABTM relationship' do
+          subject
+          expect(team.shifts).to match_array([shift])
+        end
+
+        it 'leaves the original shift_id intact' do
+          expect { subject }.not_to change(team, :shift_id)
+        end
+      end
+    end
+  end
+
+  describe 'down' do
+
+  end
+end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -24,13 +24,13 @@
 require 'rails_helper'
 
 RSpec.describe Team, type: :model do
-  let(:team) { create :team, tournament: create(:tournament) }
+  let(:tournament) { create :tournament }
 
   describe 'creation callbacks' do
     subject { team.save }
 
     context 'on a new team' do
-      let(:team) { build(:team, tournament: create(:tournament)) }
+      let(:team) { build(:team, tournament: tournament) }
 
       it 'generates an identifier upon initial save' do
         expect { subject }.to change(team, :identifier).from(nil).to(anything)
@@ -38,10 +38,13 @@ RSpec.describe Team, type: :model do
     end
 
     context 'on an existing team' do
+      let(:team) { create :team, tournament: tournament }
+
       it 'does not change the identifier, even if the name has changed' do
         team.name = team.name + ' for real'
         expect { subject }.not_to change(team, :identifier)
       end
     end
   end
+
 end

--- a/spec/requests/director/bowlers_spec.rb
+++ b/spec/requests/director/bowlers_spec.rb
@@ -499,7 +499,6 @@ describe Director::BowlersController, type: :request do
     let(:tournament) { create :tournament, :with_additional_questions }
     let(:team) { create :team, tournament: tournament }
     let(:partner_params) { {} }
-    let(:additional_question_response_params) { {} }
     let(:params) do
       {
         bowler: create_bowler_test_data.merge({
@@ -530,8 +529,26 @@ describe Director::BowlersController, type: :request do
       expect(json['team']['identifier']).to eq(team.identifier)
     end
 
-    context 'including additional question responses' do
+    it 'includes the additional question responses' do
+      subject
+      expect(json['additional_question_responses']).to have_key('pronouns')
+    end
 
+    context 'without extraneous data' do
+      let(:params) do
+        {
+          bowler: create_bowler_slimmed_down_test_data.merge({
+            team: {
+              identifier: team.identifier,
+            },
+          })
+        }
+      end
+
+      it 'succeeds with a 201 Created' do
+        subject
+        expect(response).to have_http_status(:created)
+      end
     end
 
     context 'as an unpermitted user' do

--- a/spec/requests/director/config_items_spec.rb
+++ b/spec/requests/director/config_items_spec.rb
@@ -18,7 +18,7 @@ describe Director::ConfigItemsController, type: :request do
 
     let(:tournament_identifier) { tournament.identifier }
     let(:tournament) { create :tournament }
-    let(:config_item) { create :config_item, :team_size, tournament: tournament }
+    let(:config_item) { tournament.config_items.find_by(key: 'team_size') }
     let(:config_item_id) { config_item.id }
 
     let(:params) do
@@ -34,6 +34,27 @@ describe Director::ConfigItemsController, type: :request do
     it 'succeeds with a 200 OK' do
       subject
       expect(response).to have_http_status(:ok)
+    end
+
+    context 'updating the bowler form fields' do
+      let(:config_item) { tournament.config_items.find_by_key(:bowler_form_fields) }
+      let(:params) do
+        {
+          config_item: {
+            value: 'uno dos tres',
+          }
+        }
+      end
+
+      it 'succeeds with a 200 OK' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'succeeds with a 200 OK' do
+        subject
+        expect(json['value']).to match_array(%w(uno dos tres));
+      end
     end
 
     context 'an active tournament' do

--- a/spec/requests/director/config_items_spec.rb
+++ b/spec/requests/director/config_items_spec.rb
@@ -83,7 +83,7 @@ describe Director::ConfigItemsController, type: :request do
         end
 
         context 'website' do
-          let(:config_item) { create :config_item, :website, value: 'foo.bar', tournament: tournament }
+          let(:config_item) { tournament.config_items.find_by(key: 'website') }
           let(:params) do
             {
               config_item: {

--- a/spec/requests/director/teams_spec.rb
+++ b/spec/requests/director/teams_spec.rb
@@ -22,19 +22,19 @@ describe Director::TeamsController, type: :request do
 
     before do
       10.times do
-        create :team, :standard_full_team, tournament: tournament, shift: shift
+        create :team, :standard_full_team, tournament: tournament
       end
 
       2.times do
-        create :team, :standard_one_bowler, tournament: tournament, shift: shift
+        create :team, :standard_one_bowler, tournament: tournament
       end
 
       2.times do
-        create :team, :standard_two_bowlers, tournament: tournament, shift: shift
+        create :team, :standard_two_bowlers, tournament: tournament
       end
 
       1.times do
-        create :team, :standard_three_bowlers, tournament: tournament, shift: shift
+        create :team, :standard_three_bowlers, tournament: tournament
       end
     end
 

--- a/spec/requests/director/tournaments_spec.rb
+++ b/spec/requests/director/tournaments_spec.rb
@@ -530,7 +530,7 @@ describe Director::TournamentsController, type: :request do
             timezone: 'Pacific/Honolulu',
             config_items_attributes: [
               {
-                key: 'website',
+                key: 'travel-site',
                 value: 'http://maui.hawaii.us',
               },
             ],
@@ -549,9 +549,9 @@ describe Director::TournamentsController, type: :request do
         expect{ subject }.to change(tournament.config_items, :count).by(1)
       end
 
-      it 'creates a website config item' do
+      it 'creates a travel-site config item' do
         subject
-        expect(tournament.config[:website]).to eq('http://maui.hawaii.us')
+        expect(tournament.config['travel-site']).to eq('http://maui.hawaii.us')
       end
     end
 

--- a/spec/requests/teams_spec.rb
+++ b/spec/requests/teams_spec.rb
@@ -136,14 +136,19 @@ describe TeamsController, type: :request do
       #   end
       # end
       #
-      # context "but we need one, because this is a mix-and-match tournament" do
-      #   let(:tournament) { create :tournament, :active, :mix_and_match_shifts }
-      #
-      #   it 'fails' do
-      #     subject
-      #     expect(response).to have_http_status(:unprocessable_entity)
-      #   end
-      # end
+      context "but we need one, because this is a mix-and-match tournament" do
+        let(:tournament) { create :tournament, :active, :mix_and_match_shifts }
+
+        it 'fails' do
+          subject
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it 'with a useful error message' do
+          subject
+          expect(json['team']).not_to be_nil
+        end
+      end
     end
 
     context 'a tournament with multiple inclusive shifts' do

--- a/spec/requests/teams_spec.rb
+++ b/spec/requests/teams_spec.rb
@@ -149,12 +149,29 @@ describe TeamsController, type: :request do
     context 'a tournament with multiple inclusive shifts' do
       let(:tournament) { create :tournament, :active, :two_shifts }
 
-      # We don't need to do additional testing; if the client supplies a shift,
-      # that's all we need
-      it 'succeeds' do
-        subject
-        expect(response).to have_http_status(:created)
+      context 'when a shift is full' do
+        before do
+          tournament.shifts.second.update(is_full: true)
+        end
+
+        it 'succeeds' do
+          subject
+          expect(response).to have_http_status(:created)
+        end
+
+        context 'requesting the full shift' do
+          before do
+            tournament.shifts.first.update(is_full: true)
+            tournament.shifts.second.update(is_full: false)
+          end
+
+          it 'fails' do
+            subject
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+        end
       end
+
     end
 
     context 'a tournament with mix-and-match shifts' do
@@ -196,31 +213,6 @@ describe TeamsController, type: :request do
         #   subject
         #   expect(response).to have_http_status(:unprocessable_entity)
         # end
-      end
-    end
-
-    context 'when a shift is full' do
-      let(:tournament) { create :tournament, :active, :with_entry_fee, :two_shifts }
-
-      before do
-        tournament.shifts.second.update(is_full: true)
-      end
-
-      it 'succeeds' do
-        subject
-        expect(response).to have_http_status(:created)
-      end
-
-      context 'requesting the full shift' do
-        before do
-          tournament.shifts.first.update(is_full: true)
-          tournament.shifts.second.update(is_full: false)
-        end
-
-        it 'fails' do
-          subject
-          expect(response).to have_http_status(:unprocessable_entity)
-        end
       end
     end
 

--- a/spec/requests/teams_spec.rb
+++ b/spec/requests/teams_spec.rb
@@ -12,7 +12,7 @@ describe TeamsController, type: :request do
     subject { post uri, params: new_team_params, as: :json }
 
     let(:uri) { "/tournaments/#{tournament.identifier}/teams" }
-    let(:tournament) { create :tournament, :active, :with_entry_fee }
+    let(:tournament) { create :tournament, :active }
     let!(:shift) { tournament.shifts.first }
 
     before do
@@ -27,7 +27,14 @@ describe TeamsController, type: :request do
 
     let(:new_team_params) do
       {
-        team: single_bowler_team_test_data.merge({ shift_identifier: shift.identifier }),
+        team: single_bowler_team_test_data.merge(shift_params),
+      }
+    end
+    let(:shift_params) do
+      {
+        shifts: [{
+          identifier: shift.identifier,
+        }],
       }
     end
 
@@ -64,34 +71,11 @@ describe TeamsController, type: :request do
       expect(tournament_id).to eq(tournament.id)
     end
 
-    context 'somehow with no shift identifier' do
-      let(:new_team_params) do
-        {
-          team: single_bowler_team_test_data,
-        }
-      end
-
-      it 'succeeds' do
-        subject
-        expect(response).to have_http_status(:created)
-      end
-
-      context "but we need one, because there are multiple shifts" do
-        let!(:shift2) { create :shift, tournament: tournament }
-
-        it 'fails' do
-          subject
-          expect(response).to have_http_status(:unprocessable_entity)
-        end
-      end
-    end
-
     context 'with an initial size of 3' do
       let(:new_team_params) do
         {
-          team: single_bowler_team_test_data.merge(
+          team: single_bowler_team_test_data.merge(shift_params).merge(
             'initial_size' => '3',
-            'shift_identifier' => shift.identifier,
           ),
         }
       end
@@ -117,6 +101,85 @@ describe TeamsController, type: :request do
         expect(dp.value).to eq('new_team')
       end
 
+    end
+
+    context 'somehow with no shift identifier' do
+      let(:shift_params) { {} }
+
+      it 'succeeds' do
+        subject
+        expect(response).to have_http_status(:created)
+      end
+
+      context "but we need one, because there are multiple shifts" do
+        let(:tournament) { create :tournament, :active, :two_shifts }
+
+        it 'fails' do
+          subject
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context "but we need one, because this is a mix-and-match tournament" do
+        let(:tournament) { create :tournament, :active, :mix_and_match_shifts }
+
+        it 'fails' do
+          subject
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    context 'a tournament with multiple inclusive shifts' do
+      let(:tournament) { create :tournament, :active, :two_shifts }
+
+      # We don't need to do additional testing; if the client supplies a shift,
+      # that's all we need
+      it 'succeeds' do
+        subject
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'a tournament with mix-and-match shifts' do
+      let(:tournament) { create :tournament, :active, :mix_and_match_shifts }
+      let(:shift_params) do
+        {
+          shifts: [
+            {
+              identifier: tournament.events.team.first.shifts.first.identifier,
+            },
+            {
+              identifier: tournament.events.double.first.shifts.last.identifier,
+            }
+          ],
+        }
+      end
+
+      it 'succeeds' do
+        subject
+        expect(response).to have_http_status(:created)
+      end
+
+      # This is worth doing, though maybe not initially.
+      # ...
+      # My client code will not let this happen, but never trust the public not to mess things up.
+      context 'missing a shift for a set of events' do
+        let(:shift_params) do
+          {
+            shifts: [
+              {
+                identifier: tournament.events.team.first.shifts.first.identifier,
+              },
+            ],
+          }
+        end
+
+        # it 'fails' do
+        #   subject
+        #   expect(response).to have_http_status(:unprocessable_entity)
+        # end
+      end
     end
 
     context 'when a shift is full' do
@@ -162,21 +225,22 @@ describe TeamsController, type: :request do
     subject { get uri, headers: headers, as: :json }
 
     let(:uri) { "/tournaments/#{tournament.identifier}/teams" }
-    let(:tournament) { create :tournament, :active, :one_shift }
-    let(:shift) { tournament.shifts.first }
+    let(:tournament) { create :tournament, :active }
     let(:expected_keys) { %w(identifier name size) }
 
     before do
-      create :team, :standard_one_bowler, shift: shift, tournament: tournament
-      create :team, :standard_one_bowler, shift: shift, tournament: tournament
-      create :team, :standard_two_bowlers, shift: shift, tournament: tournament
-      create :team, :standard_two_bowlers, shift: shift, tournament: tournament
-      create :team, :standard_three_bowlers, shift: shift, tournament: tournament
-      create :team, :standard_three_bowlers, shift: shift, tournament: tournament
-      create :team, :standard_three_bowlers, shift: shift, tournament: tournament
-      create :team, :standard_full_team, shift: shift, tournament: tournament
-      create :team, :standard_full_team, shift: shift, tournament: tournament
-      create :team, :standard_full_team, shift: shift, tournament: tournament
+      tournament.teams += [
+        build(:team, :standard_one_bowler),
+        build(:team, :standard_one_bowler),
+        build(:team, :standard_two_bowlers),
+        build(:team, :standard_two_bowlers),
+        build(:team, :standard_three_bowlers),
+        build(:team, :standard_three_bowlers),
+        build(:team, :standard_three_bowlers),
+        build(:team, :standard_full_team),
+        build(:team, :standard_full_team),
+        build(:team, :standard_full_team),
+      ]
     end
 
     it 'returns an array' do
@@ -194,8 +258,8 @@ describe TeamsController, type: :request do
     subject { get uri, headers: headers, as: :json }
 
     let(:uri) { "/teams/#{team.identifier}" }
-    let(:tournament) { create :tournament, :active, :one_shift }
-    let!(:team) { create :team, :standard_full_team, shift: tournament.shifts.first, tournament: tournament }
+    let(:tournament) { create :tournament, :active }
+    let!(:team) { create :team, :standard_full_team, tournament: tournament }
     let(:expected_keys) { %w(identifier name initial_size bowlers) }
 
     it 'succeeds' do
@@ -221,6 +285,67 @@ describe TeamsController, type: :request do
     it 'returns the expected bowlers in the body' do
       subject
       expect(json['bowlers'].count).to eq(team.bowlers.count)
+    end
+
+    context 'A regular tournament with a single shift' do
+      let(:shift) { tournament.shifts.last }
+
+      before do
+        team.shifts << shift
+      end
+
+      it 'returns the expected shift in the body' do
+        subject
+        expect(json['shifts'][0]['identifier']).to eq(shift.identifier)
+      end
+    end
+
+    context 'in a tournament with a shift preference for all events' do
+      let(:tournament) { create :tournament, :active, :two_shifts }
+      let(:shift) { tournament.shifts.last }
+
+      before do
+        team.shifts << shift
+      end
+
+      it 'returns the expected shift in the body' do
+        subject
+        expect(json['shifts'][0]['identifier']).to eq(shift.identifier)
+      end
+    end
+
+    context 'with mix-and-match shift preferences' do
+      let(:tournament) { create :tournament, :active, :mix_and_match_shifts }
+
+      # Assumption: knowledge of how the events are distributed among the shifts.
+      #
+      # Future enhancement: it might be useful to add some kind of identifier
+      # to each shift that's a hash or shorthand indicating which events it
+      # includes, for the ability to easily query them, e.g., give me the shifts
+      # that cover X and Y events, knowing how "X and Y events" gets hashed and
+      # using that in the where, rather than building a complicated query with joins.
+      before do
+        team.shifts = [
+          tournament.events.team.first.shifts.first,
+          tournament.events.double.first.shifts.last,
+        ]
+      end
+
+      it 'includes multiple shifts in the body' do
+        subject
+        expect(json['shifts'].count).to eq(2)
+      end
+
+      it 'includes the correct shifts' do
+        subject
+        # This purposefully duplicates the selection of shifts above
+        expected = [
+          tournament.events.team.first.shifts.first.identifier,
+          tournament.events.double.first.shifts.last.identifier,
+        ]
+        actual = json['shifts'].collect { |shift| shift['identifier'] }
+        expect(actual).to match_array(expected)
+      end
     end
 
     context 'a team that does not exist' do

--- a/spec/serializers/config_item_serializer_spec.rb
+++ b/spec/serializers/config_item_serializer_spec.rb
@@ -21,7 +21,7 @@ require 'rails_helper'
 
 RSpec.describe ConfigItemSerializer do
   let(:tournament) { create :tournament }
-  let(:config_item) { create :config_item, :team_size, tournament: tournament }
+  let(:config_item) { tournament.config_items.find_by(key: 'team_size') }
 
   subject { ConfigItemSerializer.new(config_item).serialize }
 

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -262,6 +262,31 @@ module ApiHelpers
     }
   end
 
+  def create_bowler_slimmed_down_test_data
+    {
+      'position' => '3',
+      'person_attributes' => {
+        'first_name' => 'Giacomo',
+        'last_name' => 'Hale',
+        'usbc_id' => '6621-43399',
+        'nickname' => 'Gio',
+        'phone' => '814-499-4750',
+        'email' => 'lite@yahoo.com',
+      },
+      'additional_question_responses' => [
+        {
+          'name' => 'pronouns',
+          'response' => 'something else',
+        },
+        {
+          'name' => 'comment',
+          'response' => 'I like pizza!',
+        },
+      ],
+    }
+  end
+
+
   def invalid_create_bowler_test_data
     {
       'person_attributes' => {


### PR DESCRIPTION
* Full support for mix-and-match shift tournaments
* Make a bunch of registration fields optional to the tournament
* Better form UX when clicking between positions
* Clearer distinction among tournament types (standard, multi-shift, mix-and-match)
* Re-use BowlerForm on the admin side