### PR TITLE
refactor the way we do shifts in CSV

### DIFF
--- a/app/lib/director_utilities.rb
+++ b/app/lib/director_utilities.rb
@@ -193,6 +193,8 @@ module DirectorUtilities
 
     csv_data = csv_bowlers(tournament: tournament)
 
+    return '' unless csv_data.present?
+
     headers = csv_data.first.keys
     people = csv_data.map(&:values)
 

--- a/app/lib/director_utilities.rb
+++ b/app/lib/director_utilities.rb
@@ -178,14 +178,12 @@ module DirectorUtilities
         team_id: team.id, # team.identifier,
         team_name: team.name,
         team_order: bowler.position,
-        preferred_shift: team.shifts.collect(&:name).join(', '),
       }
     else
       {
         team_id: 'n/a',
         team_name: 'n/a',
         team_order: 'n/a',
-        preferred_shift: 'n/a',
       }
     end
   end
@@ -210,12 +208,35 @@ module DirectorUtilities
       d = bowler.doubles_partner
       doubles_deets = doubles_partner_info(partner: d, name_only: true)
       bowler_data = bowler_export(bowler: bowler)
+      shift_data = shift_data(bowler: bowler)
 
       # CSV wants phone, not phone1, which is what the IGBOTS export wants
       bowler_data[:phone] = bowler_data.delete(:phone1)
 
-      bowler_data.merge(team_deets).merge(doubles_deets).merge(csv_specific_data(bowler: bowler))
+      bowler_data.merge(team_deets).merge(doubles_deets).merge(csv_specific_data(bowler: bowler)).merge(shift_data)
     end
+  end
+
+  def self.shift_data(bowler:)
+    data = {}
+    team = bowler.team
+    tournament = bowler.tournament
+
+    if tournament.config['tournament_type'] == Tournament::IGBO_MIX_AND_MATCH
+      tournament.shifts.collect(&:event_string).each do |event_string|
+        data["shift preference: #{event_string}"] = 'n/a'
+      end
+
+      if team.present?
+        team.shifts.each do |shift|
+          data["shift preference: #{shift.event_string}"] = shift.name
+        end
+      end
+    elsif tournament.config['tournament_type'] == Tournament::IGBO_MULTI_SHIFT
+      data['shift preference'] = team.present? ? team.shifts.first.name : 'n/a'
+    end
+
+    data
   end
 
   def self.csv_specific_data(bowler:)

--- a/spec/factories/tournaments.rb
+++ b/spec/factories/tournaments.rb
@@ -82,6 +82,7 @@ FactoryBot.define do
 
     trait :two_shifts do
       after(:create) do |t, _|
+        t.config_items.find_by(key: 'tournament_type').update(value: Tournament::IGBO_MULTI_SHIFT)
         create :shift, tournament: t, name: 'Second Shift', display_order: 2
       end
     end
@@ -96,6 +97,7 @@ FactoryBot.define do
 
     trait :mix_and_match_shifts do
       after(:create) do |t, _|
+        t.config_items.find_by(key: 'tournament_type').update(value: Tournament::IGBO_MIX_AND_MATCH)
         singles = create :event, :singles, tournament: t
         doubles = create :event, :doubles, tournament: t
         team = create :event, :team, tournament: t

--- a/spec/lib/director_utilities_spec.rb
+++ b/spec/lib/director_utilities_spec.rb
@@ -338,56 +338,48 @@ RSpec.describe DirectorUtilities do
     require 'csv'
 
     let(:shift_headers) { [] }
-    let(:csv_headers) { %w[id last_name first_name nickname birth_day birth_month birth_year address1 address2 city state country postal_code phone email usbc_number team_id team_name team_order entry_fee_paid registered_at doubles_last_name doubles_first_name average handicap igbo_member] + shift_headers }
+    let(:csv_headers) { [] }
 
     let(:tournament) { create :tournament, :one_shift }
-    let(:team) { create :team, tournament: tournament }
-    let!(:b1) { create(:bowler, tournament: tournament, position: 1, person: create(:person), team: team) }
-    let!(:b2) { create(:bowler, tournament: tournament, position: 2, person: create(:person), team: team) }
-    let!(:b3) { create(:bowler, tournament: tournament, position: 3, person: create(:person), team: team) }
-    let!(:b4) { create(:bowler, tournament: tournament, position: 4, person: create(:person), team: team) }
-
     let(:entry_fee_amount) { 101 }
     let!(:entry_fee_item) { create(:purchasable_item, :entry_fee, value: entry_fee_amount, tournament: tournament) }
 
-    before do
-      b1.purchases << Purchase.new(purchasable_item: entry_fee_item)
-      b2.purchases << Purchase.new(purchasable_item: entry_fee_item)
-      b3.purchases << Purchase.new(purchasable_item: entry_fee_item)
-      b4.purchases << Purchase.new(purchasable_item: entry_fee_item)
-
-      b1.update(doubles_partner: b2)
-      b2.update(doubles_partner: b1)
-      b3.update(doubles_partner: b4)
-      b4.update(doubles_partner: b3)
+    it 'is an empty string' do
+      expect(subject).to eq('')
     end
 
-    it 'is a string' do
-      expect(subject).to be_instance_of(String)
-    end
+    context 'when bowler data are present' do
+      let(:csv_headers) { %w[id last_name first_name nickname birth_day birth_month birth_year address1 address2 city state country postal_code phone email usbc_number team_id team_name team_order entry_fee_paid registered_at doubles_last_name doubles_first_name average handicap igbo_member] + shift_headers }
 
-    it 'is parsable as CSV' do
-      expect { CSV.parse(subject) }.not_to raise_error
-    end
-
-    it 'has each registered bowler' do
-      parsed = CSV.parse(subject)
-      expect(parsed.count).to eq(5) # one for header row, plus 4 bowlers
-    end
-
-    it 'has the right headers' do
-      headers = CSV.parse_line(subject)
-      expect(headers).to match_array(csv_headers)
-    end
-
-    context 'in a multi-shift tournament' do
-      let(:tournament) { create :tournament, :two_shifts}
-      let(:shift) { tournament.shifts.first }
-
-      let(:shift_headers) { ['shift preference'] }
+      let(:team) { create :team, tournament: tournament }
+      let!(:b1) { create(:bowler, tournament: tournament, position: 1, person: create(:person), team: team) }
+      let!(:b2) { create(:bowler, tournament: tournament, position: 2, person: create(:person), team: team) }
+      let!(:b3) { create(:bowler, tournament: tournament, position: 3, person: create(:person), team: team) }
+      let!(:b4) { create(:bowler, tournament: tournament, position: 4, person: create(:person), team: team) }
 
       before do
-        team.update(shifts: [shift]);
+        b1.purchases << Purchase.new(purchasable_item: entry_fee_item)
+        b2.purchases << Purchase.new(purchasable_item: entry_fee_item)
+        b3.purchases << Purchase.new(purchasable_item: entry_fee_item)
+        b4.purchases << Purchase.new(purchasable_item: entry_fee_item)
+
+        b1.update(doubles_partner: b2)
+        b2.update(doubles_partner: b1)
+        b3.update(doubles_partner: b4)
+        b4.update(doubles_partner: b3)
+      end
+
+      it 'is a string' do
+        expect(subject).to be_instance_of(String)
+      end
+
+      it 'is parsable as CSV' do
+        expect { CSV.parse(subject) }.not_to raise_error
+      end
+
+      it 'has each registered bowler' do
+        parsed = CSV.parse(subject)
+        expect(parsed.count).to eq(5) # one for header row, plus 4 bowlers
       end
 
       it 'has the right headers' do
@@ -395,33 +387,49 @@ RSpec.describe DirectorUtilities do
         expect(headers).to match_array(csv_headers)
       end
 
-      it 'has the right shift' do
-        parsed = CSV.parse(subject)
-        shift_name = parsed[1][-1]
-        expect(shift_name).to eq(shift.name)
+      context 'in a multi-shift tournament' do
+        let(:tournament) { create :tournament, :two_shifts}
+        let(:shift) { tournament.shifts.first }
+
+        let(:shift_headers) { ['shift preference'] }
+
+        before do
+          team.update(shifts: [shift]);
+        end
+
+        it 'has the right headers' do
+          headers = CSV.parse_line(subject)
+          expect(headers).to match_array(csv_headers)
+        end
+
+        it 'has the right shift' do
+          parsed = CSV.parse(subject)
+          shift_name = parsed[1][-1]
+          expect(shift_name).to eq(shift.name)
+        end
       end
-    end
 
-    context 'in a mix-and-match tournament' do
-      let(:tournament) { create :tournament, :mix_and_match_shifts}
-      let(:sd_shift) { tournament.shifts.find_by(event_string: 'double_single') }
-      let(:t_shift) { tournament.shifts.find_by(event_string: 'team') }
+      context 'in a mix-and-match tournament' do
+        let(:tournament) { create :tournament, :mix_and_match_shifts}
+        let(:sd_shift) { tournament.shifts.find_by(event_string: 'double_single') }
+        let(:t_shift) { tournament.shifts.find_by(event_string: 'team') }
 
-      let(:shift_headers) { ['shift preference: double_single', 'shift preference: team'] }
+        let(:shift_headers) { ['shift preference: double_single', 'shift preference: team'] }
 
-      before do
-        team.update(shifts: [sd_shift, t_shift]);
-      end
+        before do
+          team.update(shifts: [sd_shift, t_shift]);
+        end
 
-      it 'has the right headers' do
-        headers = CSV.parse_line(subject)
-        expect(headers).to match_array(csv_headers)
-      end
+        it 'has the right headers' do
+          headers = CSV.parse_line(subject)
+          expect(headers).to match_array(csv_headers)
+        end
 
-      it 'has the right shifts' do
-        parsed = CSV.parse(subject)
-        cells = parsed[1][-2..-1]
-        expect(cells).to eq([sd_shift.name, t_shift.name])
+        it 'has the right shifts' do
+          parsed = CSV.parse(subject)
+          cells = parsed[1][-2..-1]
+          expect(cells).to eq([sd_shift.name, t_shift.name])
+        end
       end
     end
   end


### PR DESCRIPTION
- don't include it on standard tournaments
- separate columns for each set of events, for mix-and-match tournaments
- prepare for shifts to be bowler-linked rather than team-linked