### PR TITLE
Add human-friendly date strings to tournament serializer

### DIFF
--- a/app/serializers/tournament_serializer.rb
+++ b/app/serializers/tournament_serializer.rb
@@ -61,4 +61,8 @@ class TournamentSerializer < JsonSerializer
       hash[key] = t.config[key]
     end
   end
+
+  attribute :starting_date do |t|
+    t.start_date.strftime '%B %e, %Y'
+  end
 end

--- a/app/serializers/tournament_serializer.rb
+++ b/app/serializers/tournament_serializer.rb
@@ -65,4 +65,8 @@ class TournamentSerializer < JsonSerializer
   attribute :starting_date do |t|
     t.start_date.strftime '%B %e, %Y'
   end
+
+  attribute :ending_date do |t|
+    t.end_date.strftime '%B %e, %Y'
+  end
 end

--- a/spec/requests/tournaments_spec.rb
+++ b/spec/requests/tournaments_spec.rb
@@ -13,7 +13,7 @@ describe TournamentsController, type: :request do
 
     let(:uri) { '/tournaments' }
 
-    let(:expected_keys) { %w(identifier name state startDate startingDate location) }
+    let(:expected_keys) { %w(identifier name state startDate startingDate endingDate location) }
 
     let!(:setup_tournament) { create :tournament }
     let!(:testing_tournament) { create :tournament, :testing }

--- a/spec/requests/tournaments_spec.rb
+++ b/spec/requests/tournaments_spec.rb
@@ -13,7 +13,7 @@ describe TournamentsController, type: :request do
 
     let(:uri) { '/tournaments' }
 
-    let(:expected_keys) { %w(identifier name state startDate location) }
+    let(:expected_keys) { %w(identifier name state startDate startingDate location) }
 
     let!(:setup_tournament) { create :tournament }
     let!(:testing_tournament) { create :tournament, :testing }


### PR DESCRIPTION
Because client-side date parsing is still a mess.